### PR TITLE
Fix to get the checks from the native config file

### DIFF
--- a/lib/codacy/credo/config.ex
+++ b/lib/codacy/credo/config.ex
@@ -51,10 +51,23 @@ defmodule Codacy.Credo.Config do
   defp extract_checks(%{tools: tools}) do
     patterns_map = Codacy.Credo.Generator.Patterns.pattern_id_map()
 
+    patterns =
     tools
     |> Enum.find(fn tool -> tool.name == "credo" end)
     |> Map.get(:patterns)
-    |> Enum.map(&transform_pattern_to_check(&1, patterns_map))
+
+    if is_nil(patterns) do
+      srcPath()
+      |> Credo.ConfigFile.read_or_default()
+      |> Map.get(:checks)
+    else
+      patterns
+      |> Enum.map(&transform_pattern_to_check(&1, patterns_map))
+    end
+  end
+
+  def srcPath do
+    "/src/"
   end
 
   defp transform_pattern_to_check(%{patternId: pattern_id, parameters: parameters}, patterns_map)

--- a/lib/codacy_credo.ex
+++ b/lib/codacy_credo.ex
@@ -7,7 +7,7 @@ defmodule Codacy.Credo do
     # I'm Just a fancy Script that starts Credo with the prescribed startup settings
     Credo.Application.start(nil, nil)
 
-    "/src/"
+    Config.srcPath()
     |> Config.load_config()
     |> Config.extract_credo_config()
     |> run()


### PR DESCRIPTION
Fix to get the checks from the native config file, if no pattern exists on the .codacy.json file