### PR TITLE
Fix tests with duplicated issues on the same line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,11 +70,11 @@ jobs:
       - run: 
           name: Test json
           working_directory: ~/codacy-plugins-test
-          command: sbt -Dcodacy.tests.ignore.descriptions=true "run-main codacy.plugins.DockerTest json $CIRCLE_PROJECT_REPONAME:latest"
+          command: sbt -Dcodacy.tests.ignore.descriptions=true "runMain codacy.plugins.DockerTest json $CIRCLE_PROJECT_REPONAME:latest"
       - run:
           name: Test patterns
           working_directory: ~/codacy-plugins-test
-          command: sbt -Dcodacy.tests.noremove=true -Dcodacy.tests.threads=8 "run-main codacy.plugins.DockerTest pattern $CIRCLE_PROJECT_REPONAME:latest"
+          command: sbt -Dcodacy.tests.noremove=true -Dcodacy.tests.threads=8 "runMain codacy.plugins.DockerTest pattern $CIRCLE_PROJECT_REPONAME:latest"
 
   publish:
     machine: true

--- a/docs/tests/readability_large_numbers.ex
+++ b/docs/tests/readability_large_numbers.ex
@@ -9,13 +9,10 @@ defmodule CredoLargeNumbers do
     x = 1024 + 1_000_000 + 43534
 
 ##Warning: readability_large_numbers
-##Warning: readability_large_numbers
     + 1024 + 10_00_00_0 + 43534983489534298543895
 
 ##Warning: readability_large_numbers
-##Warning: readability_large_numbers
      + 1022343242344 + 1_000_000 + 43534
-     ##Warning: readability_large_numbers
 ##Warning: readability_large_numbers
     + 1024 + 1000000 + 43534
 

--- a/docs/tests/readability_space_after_commas.ex
+++ b/docs/tests/readability_space_after_commas.ex
@@ -6,9 +6,6 @@ end
 
 defmodule CredoSampleModule do
  ##Info: readability_space_after_commas
- ##Info: readability_space_after_commas
- ##Info: readability_space_after_commas
- ##Info: readability_space_after_commas
   @attribute [1,2,"three",4,5]
 end
 

--- a/docs/tests/readability_variable_names.ex
+++ b/docs/tests/readability_variable_names.ex
@@ -58,7 +58,6 @@ end
 defmodule CredoSampleModule do
   def some_function(parameter1, parameter2) do
  ##Warning: readability_variable_names
- ##Warning: readability_variable_names
     %{some_value: someValue, other_value: otherValue} = parameter1
   end
 end

--- a/docs/tests/refactor_double_boolean_negation.ex
+++ b/docs/tests/refactor_double_boolean_negation.ex
@@ -9,7 +9,6 @@ defmodule CredoSampleMod do
   !!!true
 
 ##Info: refactor_double_boolean_negation
-##Info: refactor_double_boolean_negation
   !!!!true
 
 ##Info: refactor_double_boolean_negation


### PR DESCRIPTION
With the recent update of codacy-plugins-test these tests will fail because now we don't return duplicated occurrences of the same pattern on the same line (with different offsets).